### PR TITLE
improved README docs to allow multiple parallel python 3 installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To install `Python Poetry`, or see [poetry installation details](https://python-
 
 - Linux, macOS, Windows (WSL):
   ```bash
-  curl -sSL https://install.python-poetry.org | python3 -
+  curl -sSL https://install.python-poetry.org | python3.10 -
   ```
 - Windows (Powershell)
   ```sh


### PR DESCRIPTION
during setup walkthrough I ran into a slight issue by having other python installations on local. this change will avoid it for other users.