### PR TITLE
BIE-4187 fixed gitignore for generated internationalization files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ secrets.toml
 **/logs/
 
 
-*.mo # binary internationalization files
+# binary internationalization files
+*.mo


### PR DESCRIPTION
the comment cannot be on same line in gitignore files, otherwise the ignore won't work.